### PR TITLE
Master check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ The following commands must be available: `curl`, `jshon`, `expr`
 Usage
 ------
 
-    ./check_es_system.sh -H ESNode [-P port] [-S] [-u user] [-p pass] [-d available] -t check [-o unit] [-i indexes] [-w warn] [-c crit] [-m max_time]
+    ./check_es_system.sh -H ESNode [-P port] [-S] [-u user] [-p pass] [-d available] -t check [-o unit] [-i indexes] [-w warn] [-c crit] [-m max_time] [-e node]


### PR DESCRIPTION
This PR adds a new check type "master" to the plugin. It allows to check the current master node in an Elasticsearch cluster. With the additional parameter `-e` (expect master) a node name can be given. If the current cluster master and the node name from `-e` don't match, a warning is returned.