### PR TITLE
$warningsize and $criticalsize variables are not usable for jthreads check

### DIFF
--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -450,10 +450,10 @@ jthreads) # Check JVM threads
   if [ -n "${warning}" ] || [ -n "${critical}" ]; then
     # Handle tresholds
     thresholdlogic
-    if [[ $threads -ge $criticalsize ]]; then
+    if [[ $threads -ge $critical ]]; then
       echo "ES SYSTEM CRITICAL - Number of JVM threads is ${threads}|es_jvm_threads=${threads};${warning};${critical};;"
       exit $STATE_CRITICAL
-    elif [[ $threads -ge $warningsize ]]; then
+    elif [[ $threads -ge $warning ]]; then
       echo "ES SYSTEM WARNING - Number of JVM threads is ${threads}|es_jvm_threads=${threads};${warning};${critical};;"
       exit $STATE_WARNING
     else


### PR DESCRIPTION
$warningsize and $criticalsize are not usable for jthreads, only $warning and $critical. 
Without this error plugin returns correct values.
./check_es_system.sh -H 192.168.1.21 -t jthreads -w 100 -c 150
ES SYSTEM CRITICAL - Number of JVM threads is 183|es_jvm_threads=183;100;150;;
./check_es_system.sh -H 192.168.1.21 -t jthreads -w 150 -c 200
ES SYSTEM WARNING - Number of JVM threads is 183|es_jvm_threads=183;150;200;;
./check_es_system.sh -H 192.168.1.21 -t jthreads -w 200 -c 250
ES SYSTEM OK - Number of JVM threads is 183|es_jvm_threads=183;200;250;;
