### PR TITLE
Issue 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please refer to https://www.claudiokuenzler.com/monitoring-plugins/check_es_syst
 Requirements
 ------
 - The following commands must be available: `curl`, `expr`
-- One of the following json parsers must be available: `jshon` or `jq` (defaults to jshon)
+- One of the following json parsers must be available: `jshon` or `jq` (defaults to jq)
 
 Usage
 ------

--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -53,6 +53,7 @@
 # 20200723: Add cluster name to status output                                  #
 # 20200824: Fix typo in readonly check output                                  #
 # 20200916: Internal renaming of -i parameter, use for tps check (issue #28)   #
+# 20201125: Show names of read_only indexes with jq, set jq as default parser  #
 ################################################################################
 #Variables and defaults
 STATE_OK=0              # define the exit code if status is OK
@@ -60,7 +61,7 @@ STATE_WARNING=1         # define the exit code if status is Warning
 STATE_CRITICAL=2        # define the exit code if status is Critical
 STATE_UNKNOWN=3         # define the exit code if status is Unknown
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
-version=1.10.0
+version=1.11.0
 port=9200
 httpscheme=http
 unit=G
@@ -89,7 +90,7 @@ Options:
       -c Critical threshold (see usage notes below)
       -m Maximum time in seconds to wait for response (default: 30)
       -e Expect master node (used with 'master' check)
-      -X The json parser to be used jshon or jq (default: jshon)
+      -X The json parser to be used jshon or jq (default: jq)
       -h Help!
 
 *mandatory options

--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -418,15 +418,21 @@ readonly) # Check Readonly status on given indexes
       rocount=$(echo $settings | json_parse -r -q -c -a -x settings -x index -x blocks -x read_only | grep -c true)
       roadcount=$(echo $settings | json_parse -r -q -c -a -x settings -x index -x blocks -x read_only_allow_delete | grep -c true)
       if [[ $rocount -gt 0 ]]; then
-        if [[ "$index" = "_all" ]]; then 
-          output[${icount}]=" $rocount index(es) found read-only -"
+        if [[ "$index" = "_all" ]]; then
+          if [[ $parser = "jq" ]]; then
+            roindexes=$(echo $settings | jq -r '.[].settings.index |select(.blocks.read_only == "true").provided_name')
+          fi
+          output[${icount}]=" $rocount index(es) found read-only $roindexes -"
         else output[${icount}]=" $index is read-only -"
         fi
         roerror=true
       fi
       if [[ $roadcount -gt 0 ]]; then
-        if [[ "$index" = "_all" ]]; then 
-          output[${icount}]+=" $roadcount index(es) found read-only (allow delete) -"
+        if [[ "$index" = "_all" ]]; then
+          if [[ $parser = "jq" ]]; then
+            roadindexes=$(echo $settings | jq -r '.[].settings.index |select(.blocks.read_only_allow_delete == "true").provided_name' | tr '\n' ' ')
+          fi
+          output[${icount}]+=" $roadcount index(es) found read-only (allow delete) $roadindexes"
         else output[${icount}]+=" $index is read-only (allow delete) -"
         fi
         roerror=true

--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -66,7 +66,7 @@ httpscheme=http
 unit=G
 include='_all'
 max_time=30
-parsers=(jshon jq)
+parsers=(jq jshon)
 ################################################################################
 #Functions
 help () {
@@ -198,7 +198,7 @@ do
   t)      checktype=${OPTARG};;
   m)      max_time=${OPTARG};;
   e)      expect_master=${OPTARG};;
-  X)      parser=${OPTARG:=jshon};;
+  X)      parser=${OPTARG:=jq};;
   *)      help;;
   esac
 done


### PR DESCRIPTION
This fixes #30 

- Set jq as new default json parser (was: jshon)
- Plugin now shows the names of the found read_only indexes when using jq as json parser