### PR TITLE
1.11.1

### DIFF
--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License            #
 # along with this program; if not, see <https://www.gnu.org/licenses/>.        #
 #                                                                              #
-# Copyright 2016,2018-2020 Claudio Kuenzler                                    #
+# Copyright 2016,2018-2021 Claudio Kuenzler                                    #
 # Copyright 2018 Tomas Barton                                                  #
 # Copyright 2020 NotAProfessionalDeveloper                                     #
 # Copyright 2020 tatref                                                        #
@@ -56,6 +56,7 @@
 # 20200916: Internal renaming of -i parameter, use for tps check (issue #28)   #
 # 20201110: Fix thresholds in jthreads check                                   #
 # 20201125: Show names of read_only indexes with jq, set jq as default parser  #
+# 20210616: Fix authentication bug (#38) and non ES URL responding (#39)       #
 ################################################################################
 #Variables and defaults
 STATE_OK=0              # define the exit code if status is OK
@@ -63,7 +64,7 @@ STATE_WARNING=1         # define the exit code if status is Warning
 STATE_CRITICAL=2        # define the exit code if status is Critical
 STATE_UNKNOWN=3         # define the exit code if status is Unknown
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
-version=1.11.0
+version=1.11.1
 port=9200
 httpscheme=http
 unit=G
@@ -249,6 +250,9 @@ if [[ -z $user ]]; then
   elif [[ $esstatus =~ "503 Service Unavailable" ]]; then
     echo "ES SYSTEM CRITICAL - Elasticsearch not available: ${host}:${port} return error 503"
     exit $STATE_CRITICAL
+  elif [[ $esstatus =~ "Unknown resource" ]]; then
+    echo "ES SYSTEM CRITICAL - Elasticsearch not available: ${esstatus}"
+    exit $STATE_CRITICAL
   fi
   # Additionally get cluster health infos
   if [ $checktype = status ]; then
@@ -273,6 +277,9 @@ if [[ -n $user ]] || [[ -n $(echo $esstatus | grep -i authentication) ]] ; then
     exit $STATE_CRITICAL
   elif [[ $esstatus =~ "503 Service Unavailable" ]]; then
     echo "ES SYSTEM CRITICAL - Elasticsearch not available: ${host}:${port} return error 503"
+    exit $STATE_CRITICAL
+  elif [[ $esstatus =~ "Unknown resource" ]]; then
+    echo "ES SYSTEM CRITICAL - Elasticsearch not available: ${esstatus}"
     exit $STATE_CRITICAL
   elif [[ -n $(echo $esstatus | grep -i "unable to authenticate") ]]; then
     echo "ES SYSTEM CRITICAL - Unable to authenticate user $user for REST request"
@@ -376,6 +383,7 @@ status) # Check Elasticsearch status
   ;;
 
 readonly) # Check Readonly status on given indexes
+  getstatus
   icount=0
   for index in $include; do
     if [[ -z $user ]]; then
@@ -477,6 +485,7 @@ jthreads) # Check JVM threads
   ;;
 
 tps) # Check Thread Pool Statistics
+  getstatus
   if [[ -z $user ]]; then
     # Without authentication
     threadpools=$(curl -k -s --max-time ${max_time} ${httpscheme}://${host}:${port}/_cat/thread_pool)
@@ -589,6 +598,7 @@ tps) # Check Thread Pool Statistics
   ;;
 
 master) # Check Cluster Master
+  getstatus
   if [[ -z $user ]]; then
     # Without authentication
     master=$(curl -k -s --max-time ${max_time} ${httpscheme}://${host}:${port}/_cat/master)

--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -253,6 +253,9 @@ if [[ -z $user ]]; then
   elif [[ $esstatus =~ "Unknown resource" ]]; then
     echo "ES SYSTEM CRITICAL - Elasticsearch not available: ${esstatus}"
     exit $STATE_CRITICAL
+  elif ! [[ $esstatus =~ "cluster_name" ]]; then
+    echo "ES SYSTEM CRITICAL - Elasticsearch not available at this address ${host}:${port}"
+    exit $STATE_CRITICAL
   fi
   # Additionally get cluster health infos
   if [ $checktype = status ]; then
@@ -286,6 +289,9 @@ if [[ -n $user ]] || [[ -n $(echo $esstatus | grep -i authentication) ]] ; then
     exit $STATE_CRITICAL
   elif [[ -n $(echo $esstatus | grep -i "unauthorized") ]]; then
     echo "ES SYSTEM CRITICAL - User $user is unauthorized"
+    exit $STATE_CRITICAL
+  elif ! [[ $esstatus =~ "cluster_name" ]]; then
+    echo "ES SYSTEM CRITICAL - Elasticsearch not available at this address ${host}:${port}"
     exit $STATE_CRITICAL
   fi
   # Additionally get cluster health infos


### PR DESCRIPTION
This PR fixes #38 and #39 

With this PR two bugs are fixed.

1) Invalid authentication is not properly handled and did not result in correct plugin behaviour (output and exit code) on the check types readonly, master and tps

2) Invalid domains submitted by `-H` parameter were not properly handled and resulted in the plugin to simply return OK (exit code 0) when a HTTP status 200 came back as a response.