### PR TITLE
add filter to curl request to prevent oom exceptions

### DIFF
--- a/check_es_system.sh
+++ b/check_es_system.sh
@@ -257,9 +257,11 @@ fi
 # Retrieve information from Elasticsearch cluster
 getstatus() {
 if [[ ${local} ]]; then
-  esurl="${httpscheme}://${host}:${port}/_nodes/_local/stats"
+  filter_path='cluster_name,indices.store,indices.shards,indices.docs,nodes.*.count,nodes.*.jvm.mem,nodes.*.process,nodes.*.jvm.threads,status'
+  esurl="${httpscheme}://${host}:${port}/_nodes/_local/stats?filter_path=${filter_path}"
 else
-  esurl="${httpscheme}://${host}:${port}/_cluster/stats"
+  filter_path='cluster_name,indices.store,indices.shards,indices.docs,nodes.count,nodes.jvm.mem,nodes.process,nodes.jvm.threads,status'
+  esurl="${httpscheme}://${host}:${port}/_cluster/stats?filter_path=${filter_path}"
 fi
 eshealthurl="${httpscheme}://${host}:${port}/_cluster/health"
 


### PR DESCRIPTION
Sometimes the apis response gets very long because it logs every http requests by default. On our test machine the following grep cmd filled up the 24gb memory within seconds:

`if [[ -n $user ]] || [[ -n $(echo $esstatus | grep -i authentication) ]] ; then`

We were able to mitigate it by adding a filter to the api requests to include only those values which are needed. This probably needs some more testing before merging, we only tested the memory mode