### PR TITLE
Bugfix in readonly check type for missing privileges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ before_script:
 
 script: 
         - ./check_es_system.sh --help || true
-        - |
-          test/test_status.sh
-          test/test_readonly.sh
-          test/test_disk.sh
+        - test/test_status.sh
+        - test/test_readonly.sh
+        - test/test_disk.sh
 
   

--- a/test/test_disk.sh
+++ b/test/test_disk.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo "Test Elasticsearch status"
+./check_es_system.sh -H 127.0.0.1 -P 9200 -t disk
 output=$(./check_es_system.sh -H 127.0.0.1 -P 9200 -t disk)
 
 if [[ $? -eq 0 ]]; then
@@ -10,7 +11,7 @@ else
   exitcode=1
 fi
 
-if [[ "${output}" != "ES SYSTEM OK - Disk usage is at 0% (0 G from 67 G)|es_disk=648B;58128941056;69028117504;0;72661176320" ]]; then
+if ! [[ "${output}" =~ "ES SYSTEM OK - Disk usage is at 0%" ]]; then
   exitcode=1
 fi
 


### PR DESCRIPTION
This is a bugfix for the `readonly` check type. 

Before this PR, the readonly check would silently return OK even if the check doesn't work due to missing privileges on the Elasticsearch cluster.

```
$ /usr/lib/nagios/plugins/check_es_system.sh -H elasticsearch.example.com -u "user" -p "secret" -t readonly
jq: error (at <stdin>:1): Cannot index number with string "settings"
jq: error (at <stdin>:1): Cannot index number with string "settings"
ES SYSTEM OK - Elasticsearch Indexes (_all) are writeable 
```

This PR fixes the bug and correctly identifies missing privileges:

```
$ /usr/lib/nagios/plugins/check_es_system.sh -H elasticsearch.example.com -u "user" -p "secret" -t readonly
ES SYSTEM CRITICAL - Access denied (action [indices:monitor/settings/get] is unauthorized for user [user] with roles [esmonitoring], this action is granted by the index privileges [monitor,view_index_metadata,manage,all])
```